### PR TITLE
Correct distribute org donations DB call

### DIFF
--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -1,4 +1,4 @@
-const { MongoClient, ObjectId } = require('mongodb')
+const { MongoClient } = require('mongodb')
 
 const MONGO_DB = 'flossbank_db'
 const PACKAGES_COLLECTION = 'packages'
@@ -27,22 +27,17 @@ class Mongo {
     if (this.mongoClient) return this.mongoClient.close()
   }
 
-  async distributeOrgDonation ({ donationAmount, packageWeightsMap, organizationId }) {
+  async distributeOrgDonation ({ donationAmount, packageWeightsMap, language, registry, organizationId }) {
     // if there are no weights in the map, this suggests we found no supported package manifest files
-    // in the organization's repos
+    // in the organization's repos for this language and registry
     if (!packageWeightsMap.size) {
       return
     }
 
-    const totalMass = Array.from(packageWeightsMap.values()).reduce((acc, val) => acc + val, 0)
-    const packageIds = packageWeightsMap.keys()
-
     const bulkUpdates = this.db.collection(PACKAGES_COLLECTION).initializeUnorderedBulkOp()
-    for (const id of packageIds) {
-      const packageWeight = packageWeightsMap.get(id)
-      const packagePortion = packageWeight / totalMass
-      const packageShareOfDonation = packagePortion * donationAmount
-      bulkUpdates.find({ _id: ObjectId(id) }).updateOne({
+    for (const [pkg, weight] of packageWeightsMap) {
+      const packageShareOfDonation = weight * donationAmount
+      bulkUpdates.find({ registry, language, name: pkg }).upsert().updateOne({
         $push: {
           donationRevenue: { organizationId, amount: packageShareOfDonation, timestamp: Date.now() }
         }


### PR DESCRIPTION
Old logic was copied from distribute-user-donations and this one has some differences (multiple reg/lang possibilities; more like session complete in not knowing package ids beforehand)